### PR TITLE
Fix default factory weighting

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -7896,7 +7896,7 @@
     }
 
     function findRequiredResourceWeight(resource) {
-        return state.unlockedBuildings.find(building => building.cost[resource.id] > resource.currentQuantity)?.weighting ?? 0;
+        return state.unlockedBuildings.find(building => building.cost[resource.id] > resource.currentQuantity)?.weighting;
     }
 
     function autoEvolution() {


### PR DESCRIPTION
This function should return an optional value so that its callers may decide what value to pick in case no buildings require the resource (0 for craftables, 100 for factory)