### PR TITLE
No greatness achievements for hybrid genus species

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -1532,6 +1532,7 @@
 
             const noMADRace = ["sludge", "ultra_sludge"];
             const noGenusRace = ["custom", "junker", "sludge", "ultra_sludge", "hybrid"];
+            const noGreatnessGenus = ["hybrid"];
             const challengeRace = ["junker", "sludge", "ultra_sludge"];
             const greatnessReset = ["bioseed", "ascension", "terraform", "matrix", "retire", "eden"];
             const midTierReset = ["bioseed", "cataclysm", "whitehole", "vacuum", "terraform"];
@@ -1581,7 +1582,9 @@
 
             // Check greatness\extinction achievement
             if (greatnessReset.includes(settings.prestigeType)) {
-                checkAchievement(100, "genus_" + this.genus);
+                if (!noGreatnessGenus.includes(this.genus)) {
+                    checkAchievement(100, "genus_" + this.genus);
+                }
             } else if (!noMADRace.includes(this.id) || settings.prestigeType !== "mad") {
                 checkAchievement(100, "extinct_" + this.id);
             }


### PR DESCRIPTION
Auto Achievements ends up looping over hybrid species when doing a greatness reset (eg T4 for pillars), because the `genus_hybrid` achievement doesn't exist in the game. This only shows up when all of them are done so it's not that big of a deal, but still.