### PR TITLE
Add performance hack for alchemy

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -3877,6 +3877,27 @@
             let vue = getVueById(this._alchemyVuePrefix + id);
             if (vue === undefined) { return false; }
 
+            if (settings.performanceHackAlchemy) {
+                // Avoid clean code below and instead read and manipulate game data directly to avoid loadAlchemy>vBind>addSpell
+                // `for i = 0; i < count` inner loop that causes prestige-scaled amounts of lag.
+                // We need to use and modify the "real" mana rate of change directly to match game logic.
+                const manaResourceVue = getVueById("resMana");
+                if (manaResourceVue === undefined || typeof manaResourceVue.diff !== "number" || typeof vue.a !== "object" || typeof vue.a[id] !== "number") {
+                    return;
+                }
+                const diff = Math.floor(Math.min(manaResourceVue.diff, count));
+                if (diff < 1) {
+                    return;
+                }
+
+                vue.a[id] += diff;
+                manaResourceVue.diff -= diff * 1;
+
+                resources.Mana.rateOfChange -= diff * 1;
+                resources.Crystal.rateOfChange -= diff * 0.5;
+                return;
+            }
+
             resources.Mana.rateOfChange -= count * 1;
             resources.Crystal.rateOfChange -= count * 0.5;
 
@@ -3888,6 +3909,27 @@
         transmuteLess(id, count) {
             let vue = getVueById(this._alchemyVuePrefix + id);
             if (vue === undefined) { return false; }
+
+            if (settings.performanceHackAlchemy) {
+                // Avoid clean code below and instead read and manipulate game data directly to avoid loadAlchemy>vBind>subSpell
+                // `for i = 0; i < count` inner loop that causes prestige-scaled amounts of lag.
+                // Need to be very sure we aren't removing more than we have to match game logic.
+                const manaResourceVue = getVueById("resMana");
+                if (manaResourceVue === undefined || typeof manaResourceVue.diff !== "number" || typeof vue.a !== "object" || typeof vue.a[id] !== "number") {
+                    return;
+                }
+                const diff = Math.floor(Math.min(vue.a[id], count));
+                if (diff < 1) {
+                    return;
+                }
+
+                vue.a[id] -= diff;
+                manaResourceVue.diff += diff * 1;
+
+                resources.Mana.rateOfChange += diff * 1;
+                resources.Crystal.rateOfChange += diff * 0.5;
+                return;
+            }
 
             resources.Mana.rateOfChange += count * 1;
             resources.Crystal.rateOfChange += count * 0.5;
@@ -7202,6 +7244,7 @@
             displayTotalDaysTypeInTopBar: false,
             scriptSettingsExportFilename: "evolve-script-settings.json",
             performanceHackAvoidDrawTech: false,
+            performanceHackAlchemy: false,
         }
 
         applySettings(def, reset);
@@ -15708,8 +15751,9 @@
         addSettingsHeader1(currentNode, "Misc");
         addSettingsString(currentNode, "scriptSettingsExportFilename", "Export Filename", "Configures the filename used when using the 'Script Settings as File' button. This is useful if you keep multiple different profiles around.");
 
-        addSettingsHeader1(currentNode, "Experimental");
+        addSettingsHeader1(currentNode, "Performance Hacks (Experimental)");
         addSettingsToggle(currentNode, "performanceHackAvoidDrawTech", "Enable performance hack: drawTech avoidance", "Enables very experimental and potentially buggy performance hacks designed to avoid excessive redraws of the research tab, which appears to be very CPU-intensive to redraw. This improves game performance when buying lots of buildings, but also causes potentially limitless amounts of bugs as important game code may be skipped.");
+        addSettingsToggle(currentNode, "performanceHackAlchemy", "Enable performance hack: Alchemy", "Enables experimental and potentially buggy performance hack that avoids a very performance intensive inner loop in game code when manipulating alchemy. Instead of automating clicks, the script will instead modify game data directly. Performance benefit scales with your mana production; you should leave this off unless you have extremely high prestige and the game starts to lag after building Mana Syphons (probably somewhere around 100K Mana/second but it will depend on your hardware).");
 
         document.documentElement.scrollTop = document.body.scrollTop = currentScrollPosition;
     }


### PR DESCRIPTION
Submitted as draft for now until it sees more testing. (But the code is all conditional on a setting so it might be OK, might just need more changes if I overlooked anything.)

Adds a performance hack setting to avoid calling [the game's addSpell and subSpell functions](https://github.com/pmotschmann/Evolve/blob/a2345c7296d104597e28912beb5054cb4454cd0f/src/resources.js#L2945-L2968) which are quite unoptimized. The setting is off by default.

This caused extreme freezes while doing a T4 run in magic, found by accident and then profiled:
![image](https://github.com/user-attachments/assets/2144f4c7-33ee-4e9c-945e-800b57d5d1d3)

Those game functions loop over the key multiplier, and they write to two things that trigger Vue reactivity/partial redraws _inside_ the key multiplier loop, causing lots and lots of Vue framework code to run. Even if the game's code was fixed to do this one click at a time, KeyManager's fake ctrl-shift-alt clicks only count for 25000 each, so it would still be fairly inefficient for high prestige players with 100M or more of mana/s that shuffle alchemy a lot. In my case, it was frequently shuffling 25 million worth of bolognium & orichalcum around.

There is similar code in the game's pylon functions that could probably be optimized similarly, but that has non-trivial non-linear cost scaling, and even with my save giving 100M it's only a small amount of performance lost (rituals only go to ~3000 and aren't adjusted as often). Might be relevant in the future but I don't think it's worth effort at the moment.

Luckily we can just get at the game's real copy of the alchemy data by hacking into the same Vue instance we're already 'loaning' to make fake clicks, and write to it there (and also update the mana resource accounting). So that avoids it entirely.

Relevant Discord messages: https://discord.com/channels/586926974585274373/605191634300174337/1319832071790788678 and on