### PR TITLE
Fix waygate power check to use the same prestigeType check as the research ignore

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -11514,7 +11514,7 @@
                 }
                 // Disable Waygate once it cleared, or if we're going to use bomb, or current potential is too hight
                 if (building === buildings.SpireWaygate && (haveTech("waygate", 3)
-                     || (settings.prestigeDemonicBomb && game.global.stats.spire[poly.universeAffix()]?.dlstr > 0)
+                     || (settings.prestigeDemonicBomb && settings.prestigeType === "demonic" && game.global.stats.spire[poly.universeAffix()]?.dlstr > 0)
                      || (settings.autoMech && MechManager.mechsPotential > settings.mechWaygatePotential && !(settings.autoPrestige && settings.prestigeType === "demonic" && buildings.SpireTower.count >= settings.prestigeDemonicFloor)))) {
                       maxStateOn = 0;
                 }


### PR DESCRIPTION
autoPower's waygate powering logic assumes that dark bomb will be used when the setting is on, but the script only does it for DI runs. This makes it never fight the demon lord when "use dark bomb" is enabled, the demon lord has >0 strength, and reset type is set to Apotheosis, leading to a stuck game.