### PR TITLE
Fixes for log filter & wish settings when running in userscript sandbox

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -13666,9 +13666,9 @@
         let strings = settingsRaw.logFilter.split(/[^0-9a-z_%]/g).filter(Boolean);
         for (let i = 0; i < strings.length; i++) {
             let [id, ...params] = strings[i].split("%");
-            params = params.map(game.loc);
+            params = params.map(poly.loc);
             // Loot message built from multiple strings without tokens, let's fake one for regexp below
-            let message = game.loc(id, params.length ? params : undefined) + (id === "civics_garrison_gained" ? "%0" : "");
+            let message = poly.loc(id, params.length ? params : undefined) + (id === "civics_garrison_gained" ? "%0" : "");
             if (message === id) {
                 continue;
             }
@@ -17365,10 +17365,10 @@
         addSettingsSelect(currentNode, "psychicBoostRes", "Boosted Resource", "Resource for Boost Resource Production psychic power.", psychicBoost);
 
         let wishMinor = [{ val: "none", label: "None", hint: "Disable using minor wishes." },
-            ...wishData.minor.map(w => ({ val: w.id, label: game.loc('wish_for', [game.loc(w.loc)]) }))];
+            ...wishData.minor.map(w => ({ val: w.id, label: poly.loc('wish_for', [poly.loc(w.loc)]) }))];
         addSettingsSelect(currentNode, "wishMinor", "Minor Wish", "Uses this minor wish when available.", wishMinor);
         let wishMajor = [{ val: "none", label: "None", hint: "Disable using major wishes." },
-            ...wishData.major.map(w => ({ val: w.id, label: game.loc('wish_for', [game.loc(w.loc)]) }))];
+            ...wishData.major.map(w => ({ val: w.id, label: poly.loc('wish_for', [poly.loc(w.loc)]) }))];
         addSettingsSelect(currentNode, "wishMajor", "Major Wish", "Uses this major wish when available.", wishMajor);
 
         addSettingsToggle(currentNode, "jobScalePop", "High Pop job scale", "Auto Job will automatically scaly breakpoints to match population increase");


### PR DESCRIPTION
Reported on Discord, these functions pass an array of parameters to the localization, so they need `poly.loc` instead of `game.loc` when running under the sandbox in Greasemonkey/Firefox.

I quickly grepped through the source for the other ~94 `game.loc` calls and think they don't need to be changed, it's only necessary for calls passing parameters