### PR TITLE
Add confirmation to toggles in autoBuild settings "all buildings"

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -18599,6 +18599,9 @@
             if (event[overrideKey]) {
                 event.preventDefault();
             }
+            if (event.target.nodeName === "INPUT" && !confirm("Are you sure you wish to change the Auto Build state of ALL buildings?")) {
+                event.preventDefault();
+            }
         });
     }
 
@@ -18665,6 +18668,9 @@
         })
         .on('click', function(event){
             if (event[overrideKey]) {
+                event.preventDefault();
+            }
+            if (event.target.nodeName === "INPUT" && !confirm("Are you sure you wish to change the Auto Power state of ALL buildings?")) {
                 event.preventDefault();
             }
         });


### PR DESCRIPTION
Changes a lot of things at once and should be a very infrequent action.

Figured it would be more readable if the `event.preventDefault()` was duplicated instead of trying to awkwardly fit it into the same `if` as the override check.