### PR TITLE
Harden against invalid options in researchIgnore

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -15592,7 +15592,7 @@
             case "list":
                 return $(`
                   <span></span>`)
-               .text(value.map(item => options.list[item].name).join(", "));
+               .text(value.map(item => options.list[item]?.name ?? "[Invalid item]").join(", "));
             default:
                 return $(`
                   <span></span>`)
@@ -15614,7 +15614,7 @@
                 return node.find('input').prop('checked', value);
             case "list":
                 if (id === "researchIgnore") {
-                    return node.text(value.map(item => techIds[item].name).join(", "));
+                    return node.text(value.map(item => techIds[item]?.name ?? "[Invalid item]").join(", "));
                 } // else default
             default:
                 return node.text(JSON.stringify(value));


### PR DESCRIPTION
https://discord.com/channels/586926974585274373/605191634300174337/1416090920830632077

Invalid A?B eval on researchIgnore ends up breaking the override window completely, making it impossible to remove without manual tinkering. I think this would also happen if the game ever renamed/removed tech.