### PR TITLE
Fix Banquet Hall count -> level changes in 1.4.9

### DIFF
--- a/evolve_automation.user.js
+++ b/evolve_automation.user.js
@@ -1157,6 +1157,11 @@
                 return 0;
             }
 
+            if (this === buildings.Banquet) {
+                // Banquet hall uses "level" as build count if >= 1
+                return this.instance?.count ? this.instance.level : 0;
+            }
+
             return this.instance?.count ?? 0;
         }
 
@@ -11655,6 +11660,11 @@
             }
             if (settings.buildingsLimitPowered) {
                 maxStateOn = Math.min(maxStateOn, building.autoMax);
+            }
+
+            // Banquet just has a single on/off switch even above level 1
+            if (building === buildings.Banquet) {
+                maxStateOn = Math.min(maxStateOn, 1);
             }
 
             // Max powered amount


### PR DESCRIPTION
Adjusts to changes made in https://github.com/pmotschmann/Evolve/commit/89b806c2dcddc82c0c3e71e41dd58a7298861350

Without this commit, the script can spam infinite builds for banquet hall depending on user settings, because the game's .instance.count only reports 1 banquet hall built, even when maxed.